### PR TITLE
Fix Linear Graphql Client Issues when Creating Issue/s

### DIFF
--- a/src/__tests__/graphql-client.test.ts
+++ b/src/__tests__/graphql-client.test.ts
@@ -9,7 +9,8 @@ import {
   UpdateIssuesResponse,
   SearchIssuesInput,
   SearchIssuesResponse,
-  DeleteIssueResponse
+  DeleteIssueResponse,
+  IssueBatchResponse
 } from '../features/issues/types/issue.types';
 import {
   ProjectInput,
@@ -144,7 +145,7 @@ describe('LinearGraphQLClient', () => {
       expect(mockRawRequest).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          input: [input]
+          input: input
         })
       );
 
@@ -390,7 +391,7 @@ describe('LinearGraphQLClient', () => {
         }
       ];
 
-      const result: CreateIssuesResponse = await graphqlClient.createIssues(issues);
+      const result: IssueBatchResponse = await graphqlClient.createIssues(issues);
 
       expect(result).toEqual(mockResponse.data);
       // Verify single mutation call
@@ -398,7 +399,7 @@ describe('LinearGraphQLClient', () => {
       expect(mockRawRequest).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          input: issues
+          input: { issues }
         })
       );
     });

--- a/src/core/types/tool.types.ts
+++ b/src/core/types/tool.types.ts
@@ -75,11 +75,6 @@ export const toolSchemas = {
           description: 'Project ID',
           optional: true,
         },
-        stateType: {
-          type: 'string',
-          description: 'Issue state type("triage", "backlog", "unstarted", "started", "completed", "canceled")',
-          optional: true,
-        },
         createAsUser: {
           type: 'string',
           description: 'Name to display for the created issue',
@@ -405,11 +400,6 @@ export const toolSchemas = {
               projectId: {
                 type: 'string',
                 description: 'Project ID',
-                optional: true,
-              },
-              stateType: {
-                type: 'string',
-                description: 'Issue state type("triage", "backlog", "unstarted", "started", "completed", "canceled")',
                 optional: true,
               },
               labelIds: {

--- a/src/core/types/tool.types.ts
+++ b/src/core/types/tool.types.ts
@@ -70,6 +70,16 @@ export const toolSchemas = {
           description: 'Issue priority (0-4)',
           optional: true,
         },
+        projectId: {
+          type: 'string',
+          description: 'Project ID',
+          optional: true,
+        },
+        stateType: {
+          type: 'string',
+          description: 'Issue state type("triage", "backlog", "unstarted", "started", "completed", "canceled")',
+          optional: true,
+        },
         createAsUser: {
           type: 'string',
           description: 'Name to display for the created issue',
@@ -382,9 +392,24 @@ export const toolSchemas = {
                 type: 'string',
                 description: 'Team ID',
               },
+              assigneeId: {
+                type: 'string',
+                description: 'Assignee user ID',
+                optional: true,
+              },
+              priority: {
+                type: 'number',
+                description: 'Issue priority (0-4)',
+                optional: true,
+              },
               projectId: {
                 type: 'string',
                 description: 'Project ID',
+                optional: true,
+              },
+              stateType: {
+                type: 'string',
+                description: 'Issue state type("triage", "backlog", "unstarted", "started", "completed", "canceled")',
                 optional: true,
               },
               labelIds: {

--- a/src/features/issues/handlers/issue.handler.ts
+++ b/src/features/issues/handlers/issue.handler.ts
@@ -15,7 +15,8 @@ import {
   UpdateIssuesResponse,
   SearchIssuesResponse,
   DeleteIssueResponse,
-  Issue
+  Issue,
+  IssueBatchResponse
 } from '../types/issue.types.js';
 
 /**
@@ -67,13 +68,13 @@ export class IssueHandler extends BaseHandler implements IssueHandlerMethods {
         throw new Error('Issues parameter must be an array');
       }
 
-      const result = await client.createIssues(args.issues) as CreateIssuesResponse;
+      const result = await client.createIssues(args.issues) as IssueBatchResponse;
 
-      if (!result.issueCreate.success) {
+      if (!result.issueBatchCreate.success) {
         throw new Error('Failed to create issues');
       }
 
-      const createdIssues = result.issueCreate.issues as Issue[];
+      const createdIssues = result.issueBatchCreate.issues as Issue[];
 
       return this.createResponse(
         `Successfully created ${createdIssues.length} issues:\n` +

--- a/src/features/issues/types/issue.types.ts
+++ b/src/features/issues/types/issue.types.ts
@@ -11,6 +11,7 @@ export interface CreateIssueInput {
   assigneeId?: string;
   priority?: number;
   projectId?: string;
+  stateType?: string;
 }
 
 export interface CreateIssuesInput {

--- a/src/features/issues/types/issue.types.ts
+++ b/src/features/issues/types/issue.types.ts
@@ -11,7 +11,6 @@ export interface CreateIssueInput {
   assigneeId?: string;
   priority?: number;
   projectId?: string;
-  stateType?: string;
 }
 
 export interface CreateIssuesInput {

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -2,6 +2,7 @@ import { LinearClient } from '@linear/sdk';
 import { DocumentNode } from 'graphql';
 import { 
   CreateIssueInput, 
+  CreateIssuesInput,
   CreateIssueResponse,
   CreateIssuesResponse,
   UpdateIssueInput,
@@ -54,8 +55,8 @@ export class LinearGraphQLClient {
 
   // Create single issue
   async createIssue(input: CreateIssueInput): Promise<CreateIssueResponse> {
-    const { CREATE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<CreateIssueResponse>(CREATE_ISSUES_MUTATION, { input: input });
+    const { CREATE_ISSUE_MUTATION } = await import('./mutations.js');
+    return this.execute<CreateIssueResponse>(CREATE_ISSUE_MUTATION, { input: input });
   }
 
   // Create multiple issues

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -55,13 +55,15 @@ export class LinearGraphQLClient {
   // Create single issue
   async createIssue(input: CreateIssueInput): Promise<CreateIssueResponse> {
     const { CREATE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<CreateIssueResponse>(CREATE_ISSUES_MUTATION, { input: [input] });
+    return this.execute<CreateIssueResponse>(CREATE_ISSUES_MUTATION, { input: input });
   }
 
   // Create multiple issues
-  async createIssues(issues: CreateIssueInput[]): Promise<CreateIssuesResponse> {
-    const { CREATE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<CreateIssuesResponse>(CREATE_ISSUES_MUTATION, { input: issues });
+  async createIssues(issues: CreateIssueInput[]): Promise<IssueBatchResponse> {
+    const { CREATE_BATCH_ISSUES } = await import('./mutations.js');
+    return this.execute<IssueBatchResponse>(CREATE_BATCH_ISSUES, {
+      input: { issues }
+    });
   }
 
   // Create a project

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-tag';
 
 export const CREATE_ISSUES_MUTATION = gql`
-  mutation CreateIssues($input: [IssueCreateInput!]!) {
+  mutation CreateIssues($input: IssueCreateInput!) {
     issueCreate(input: $input) {
       success
       issue {

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-tag';
 
-export const CREATE_ISSUES_MUTATION = gql`
+export const CREATE_ISSUE_MUTATION = gql`
   mutation CreateIssues($input: IssueCreateInput!) {
     issueCreate(input: $input) {
       success


### PR DESCRIPTION
# Summary

This PR aims to fix the Linear Graphql client issues when creating a single or multiple issues.

## Changes
- Added a dedicated `CREATE_ISSUE_MUTATION` mutation to create a single issue
- Using `CREATE_BATCH_ISSUES` to create multiple issues
- Add return type `IssueBatchResponse` for batch operations
- Update issue handler to use the new batch response structure
- Fix test cases to match the new API structure
- Added additional schema fields

# Why

The previous implementation was using the same mutation for both single and multiple issues creation, and when I tested them with Client and Claude Desktop App, they always failed. With this PR, we will be able to,
- Create single issue (for a given project)
- Create multiple issues (for a give project)

# Testing

Updated and executed the existing test suite to verify the functionality.