### PR TITLE
Fix Linear Personal Access Token (PAT) client initialization using apiKey instead of accessToken

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -176,7 +176,7 @@ export class LinearAuth {
         expiresAt: Number.MAX_SAFE_INTEGER, // PATs don't expire
       };
       this.linearClient = new LinearClient({
-        accessToken: config.accessToken,
+        apiKey: config.accessToken,
       });
     } else {
       // OAuth flow


### PR DESCRIPTION
## Fix LinearClient initialization to match Linear SDK documentation

This PR fixes an issue with the LinearClient initialization in the Personal Access Token (PAT) flow. According to the [Linear SDK documentation](https://developers.linear.app/docs/sdk/getting-started#id-2.-create-a-linear-client), when using API key authentication, the client should be initialized with the `apiKey` parameter rather than the `accessToken` parameter.
