### PR TITLE
fix(auth): Correct PAT handling in SDK client & update docs (v1.0.1)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,33 +1,33 @@
-import { LinearClient } from '@linear/sdk';
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { LinearClient } from "@linear/sdk";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * Solution Attempts:
- * 
+ *
  * 1. OAuth Flow with Browser (Initial Attempt)
  * - Used browser redirect and local server for OAuth flow
  * - Issues: Browser extensions interfering, CORS issues
  * - Status: Failed - Browser extensions and CORS blocking requests
- * 
+ *
  * 2. Personal Access Token (Current Attempt)
  * - Using PAT for initial integration tests
  * - Simpler approach without browser interaction
  * - Status: Working - Successfully authenticates and makes API calls
- * 
+ *
  * 3. Direct OAuth Token Exchange (Current Attempt)
  * - Using form-urlencoded content type as required by Linear
  * - Status: In Progress - Testing token exchange
  */
 
 export interface OAuthConfig {
-  type: 'oauth';
+  type: "oauth";
   clientId: string;
   clientSecret: string;
   redirectUri: string;
 }
 
 export interface PersonalAccessTokenConfig {
-  type: 'pat';
+  type: "pat";
   accessToken: string;
 }
 
@@ -40,8 +40,8 @@ export interface TokenData {
 }
 
 export class LinearAuth {
-  private static readonly OAUTH_AUTH_URL = 'https://linear.app/oauth';
-  private static readonly OAUTH_TOKEN_URL = 'https://api.linear.app';
+  private static readonly OAUTH_AUTH_URL = "https://linear.app/oauth";
+  private static readonly OAUTH_TOKEN_URL = "https://api.linear.app";
   private config?: AuthConfig;
   private tokenData?: TokenData;
   private linearClient?: LinearClient;
@@ -49,61 +49,72 @@ export class LinearAuth {
   constructor() {}
 
   public getAuthorizationUrl(): string {
-    if (!this.config || this.config.type !== 'oauth') {
+    if (!this.config || this.config.type !== "oauth") {
       throw new McpError(
         ErrorCode.InvalidRequest,
-        'OAuth config not initialized'
+        "OAuth config not initialized"
       );
     }
 
     const params = new URLSearchParams({
       client_id: this.config.clientId,
       redirect_uri: this.config.redirectUri,
-      response_type: 'code',
-      scope: 'read,write,issues:create,offline_access',
-      actor: 'application', // Enable OAuth Actor Authorization
+      response_type: "code",
+      scope: "read,write,issues:create,offline_access",
+      actor: "application", // Enable OAuth Actor Authorization
       state: this.generateState(),
-      access_type: 'offline',
+      access_type: "offline",
     });
 
     return `${LinearAuth.OAUTH_AUTH_URL}/authorize?${params.toString()}`;
   }
 
   public async handleCallback(code: string): Promise<void> {
-    if (!this.config || this.config.type !== 'oauth') {
+    if (!this.config || this.config.type !== "oauth") {
       throw new McpError(
         ErrorCode.InvalidRequest,
-        'OAuth config not initialized'
+        "OAuth config not initialized"
       );
     }
 
     try {
       const params = new URLSearchParams({
-        grant_type: 'authorization_code',
+        grant_type: "authorization_code",
         client_id: this.config.clientId,
         client_secret: this.config.clientSecret,
         redirect_uri: this.config.redirectUri,
         code,
-        access_type: 'offline'
+        access_type: "offline",
       });
 
-      const response = await fetch(`${LinearAuth.OAUTH_TOKEN_URL}/oauth/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json'
-        },
-        body: params.toString()
-      });
+      const response = await fetch(
+        `${LinearAuth.OAUTH_TOKEN_URL}/oauth/token`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+          },
+          body: params.toString(),
+        }
+      );
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Token request failed: ${response.statusText}. Response: ${errorText}`);
+        throw new Error(
+          `Token request failed: ${response.statusText}. Response: ${errorText}`
+        );
       }
 
       const data = await response.json();
+
+      // Ensure the access token doesn't have a "Bearer" prefix
+      const accessToken = data.access_token.startsWith("Bearer ")
+        ? data.access_token.substring(7)
+        : data.access_token;
+
       this.tokenData = {
-        accessToken: data.access_token,
+        accessToken: accessToken,
         refreshToken: data.refresh_token,
         expiresAt: Date.now() + data.expires_in * 1000,
       };
@@ -114,44 +125,61 @@ export class LinearAuth {
     } catch (error) {
       throw new McpError(
         ErrorCode.InternalError,
-        `OAuth token exchange failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `OAuth token exchange failed: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
       );
     }
   }
 
   public async refreshAccessToken(): Promise<void> {
-    if (!this.config || this.config.type !== 'oauth' || !this.tokenData?.refreshToken) {
+    if (
+      !this.config ||
+      this.config.type !== "oauth" ||
+      !this.tokenData?.refreshToken
+    ) {
       throw new McpError(
         ErrorCode.InvalidRequest,
-        'OAuth not initialized or no refresh token available'
+        "OAuth not initialized or no refresh token available"
       );
     }
 
     try {
       const params = new URLSearchParams({
-        grant_type: 'refresh_token',
+        grant_type: "refresh_token",
         client_id: this.config.clientId,
         client_secret: this.config.clientSecret,
-        refresh_token: this.tokenData.refreshToken
+        refresh_token: this.tokenData.refreshToken,
       });
 
-      const response = await fetch(`${LinearAuth.OAUTH_TOKEN_URL}/oauth/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json'
-        },
-        body: params.toString()
-      });
+      const response = await fetch(
+        `${LinearAuth.OAUTH_TOKEN_URL}/oauth/token`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+          },
+          body: params.toString(),
+        }
+      );
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Token refresh failed: ${response.statusText}. Response: ${errorText}`);
+        throw new Error(
+          `Token refresh failed: ${response.statusText}. Response: ${errorText}`
+        );
       }
 
       const data = await response.json();
+
+      // Ensure the access token doesn't have a "Bearer" prefix
+      const accessToken = data.access_token.startsWith("Bearer ")
+        ? data.access_token.substring(7)
+        : data.access_token;
+
       this.tokenData = {
-        accessToken: data.access_token,
+        accessToken: accessToken,
         refreshToken: data.refresh_token,
         expiresAt: Date.now() + data.expires_in * 1000,
       };
@@ -162,28 +190,32 @@ export class LinearAuth {
     } catch (error) {
       throw new McpError(
         ErrorCode.InternalError,
-        `Token refresh failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Token refresh failed: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
       );
     }
   }
 
   public initialize(config: AuthConfig): void {
-    if (config.type === 'pat') {
+    if (config.type === "pat") {
       // Personal Access Token flow
       this.tokenData = {
         accessToken: config.accessToken,
-        refreshToken: '', // Not needed for PAT
+        refreshToken: "", // Not needed for PAT
         expiresAt: Number.MAX_SAFE_INTEGER, // PATs don't expire
       };
+
+      // Use apiKey instead of accessToken for PAT authentication
       this.linearClient = new LinearClient({
-        accessToken: config.accessToken,
+        apiKey: config.accessToken,
       });
     } else {
       // OAuth flow
       if (!config.clientId || !config.clientSecret || !config.redirectUri) {
         throw new McpError(
           ErrorCode.InvalidParams,
-          'Missing required OAuth parameters: clientId, clientSecret, redirectUri'
+          "Missing required OAuth parameters: clientId, clientSecret, redirectUri"
         );
       }
       this.config = config;
@@ -194,7 +226,7 @@ export class LinearAuth {
     if (!this.linearClient) {
       throw new McpError(
         ErrorCode.InvalidRequest,
-        'Linear client not initialized'
+        "Linear client not initialized"
       );
     }
     return this.linearClient;
@@ -205,16 +237,26 @@ export class LinearAuth {
   }
 
   public needsTokenRefresh(): boolean {
-    if (!this.tokenData || !this.config || this.config.type === 'pat') return false;
+    if (!this.tokenData || !this.config || this.config.type === "pat")
+      return false;
     return Date.now() >= this.tokenData.expiresAt - 300000; // Refresh 5 minutes before expiry
   }
 
   // For testing purposes
   public setTokenData(tokenData: TokenData): void {
     this.tokenData = tokenData;
-    this.linearClient = new LinearClient({
-      accessToken: tokenData.accessToken,
-    });
+
+    // Use apiKey for PAT authentication if this is a PAT
+    if (this.config?.type === "pat") {
+      this.linearClient = new LinearClient({
+        apiKey: tokenData.accessToken,
+      });
+    } else {
+      // Otherwise use accessToken for OAuth
+      this.linearClient = new LinearClient({
+        accessToken: tokenData.accessToken,
+      });
+    }
   }
 
   private generateState(): string {

--- a/src/features/issues/handlers/issue.handler.ts
+++ b/src/features/issues/handlers/issue.handler.ts
@@ -125,7 +125,8 @@ export class IssueHandler extends BaseHandler implements IssueHandlerMethods {
 
         // Search through all teams and their states to find a matching state name
         for (const team of teams) {
-          const matchingState = team.states.find(
+          // Access the 'nodes' array within the 'states' object, matching the updated type
+          const matchingState = team.states.nodes.find(
             (state: TeamState) => state.name.toLowerCase() === stateName
           );
 

--- a/src/features/issues/types/issue.types.ts
+++ b/src/features/issues/types/issue.types.ts
@@ -1,4 +1,4 @@
-import { BaseToolResponse } from '../../../core/interfaces/tool-handler.interface.js';
+import { BaseToolResponse } from "../../../core/interfaces/tool-handler.interface.js";
 
 /**
  * Input types for issue operations
@@ -39,6 +39,18 @@ export interface SearchIssuesInput {
         eq?: string;
       };
     };
+    team?: {
+      key?: {
+        eq?: string;
+      };
+      id?: {
+        in?: string[];
+      };
+    };
+    number?: {
+      eq?: number;
+    };
+    search?: string;
   };
   teamIds?: string[];
   assigneeIds?: string[];
@@ -96,7 +108,7 @@ export interface IssueBatchResponse {
 export interface UpdateIssuesResponse {
   issueUpdate: {
     success: boolean;
-    issues: Issue[];
+    issue: Issue;
   };
 }
 
@@ -123,7 +135,9 @@ export interface DeleteIssueResponse {
 export interface IssueHandlerMethods {
   handleCreateIssue(args: CreateIssueInput): Promise<BaseToolResponse>;
   handleCreateIssues(args: CreateIssuesInput): Promise<BaseToolResponse>;
-  handleBulkUpdateIssues(args: BulkUpdateIssuesInput): Promise<BaseToolResponse>;
+  handleBulkUpdateIssues(
+    args: BulkUpdateIssuesInput
+  ): Promise<BaseToolResponse>;
   handleSearchIssues(args: SearchIssuesInput): Promise<BaseToolResponse>;
   handleDeleteIssue(args: DeleteIssueInput): Promise<BaseToolResponse>;
   handleDeleteIssues(args: DeleteIssuesInput): Promise<BaseToolResponse>;

--- a/src/features/teams/types/team.types.ts
+++ b/src/features/teams/types/team.types.ts
@@ -12,7 +12,7 @@ export interface Team {
   id: string;
   name: string;
   key: string;
-  states: TeamState[];
+  states: { nodes: TeamState[] }; // Corrected type to match likely runtime structure
 }
 
 export interface TeamResponse {

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -1,7 +1,7 @@
-import { LinearClient } from '@linear/sdk';
-import { DocumentNode } from 'graphql';
-import { 
-  CreateIssueInput, 
+import { LinearClient } from "@linear/sdk";
+import { DocumentNode } from "graphql";
+import {
+  CreateIssueInput,
   CreateIssueResponse,
   CreateIssuesResponse,
   UpdateIssueInput,
@@ -10,21 +10,19 @@ import {
   SearchIssuesResponse,
   DeleteIssueResponse,
   Issue,
-  IssueBatchResponse
-} from '../features/issues/types/issue.types.js';
+  IssueBatchResponse,
+} from "../features/issues/types/issue.types.js";
 import {
   ProjectInput,
   ProjectResponse,
-  SearchProjectsResponse
-} from '../features/projects/types/project.types.js';
+  SearchProjectsResponse,
+} from "../features/projects/types/project.types.js";
 import {
   TeamResponse,
   LabelInput,
-  LabelResponse
-} from '../features/teams/types/team.types.js';
-import {
-  UserResponse
-} from '../features/users/types/user.types.js';
+  LabelResponse,
+} from "../features/teams/types/team.types.js";
+import { UserResponse } from "../features/users/types/user.types.js";
 
 export class LinearGraphQLClient {
   private linearClient: LinearClient;
@@ -40,7 +38,7 @@ export class LinearGraphQLClient {
     const graphQLClient = this.linearClient.client;
     try {
       const response = await graphQLClient.rawRequest(
-        document.loc?.source.body || '',
+        document.loc?.source.body || "",
         variables
       );
       return response.data as T;
@@ -54,86 +52,119 @@ export class LinearGraphQLClient {
 
   // Create single issue
   async createIssue(input: CreateIssueInput): Promise<CreateIssueResponse> {
-    const { CREATE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<CreateIssueResponse>(CREATE_ISSUES_MUTATION, { input: [input] });
+    const { CREATE_ISSUES_MUTATION } = await import("./mutations.js");
+    return this.execute<CreateIssueResponse>(CREATE_ISSUES_MUTATION, {
+      input: [input],
+    });
   }
 
   // Create multiple issues
-  async createIssues(issues: CreateIssueInput[]): Promise<CreateIssuesResponse> {
-    const { CREATE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<CreateIssuesResponse>(CREATE_ISSUES_MUTATION, { input: issues });
+  async createIssues(
+    issues: CreateIssueInput[]
+  ): Promise<CreateIssuesResponse> {
+    const { CREATE_ISSUES_MUTATION } = await import("./mutations.js");
+    return this.execute<CreateIssuesResponse>(CREATE_ISSUES_MUTATION, {
+      input: issues,
+    });
   }
 
   // Create a project
   async createProject(input: ProjectInput): Promise<ProjectResponse> {
-    const { CREATE_PROJECT } = await import('./mutations.js');
+    const { CREATE_PROJECT } = await import("./mutations.js");
     return this.execute<ProjectResponse>(CREATE_PROJECT, { input });
   }
 
   // Create batch of issues
-  async createBatchIssues(issues: CreateIssueInput[]): Promise<IssueBatchResponse> {
-    const { CREATE_BATCH_ISSUES } = await import('./mutations.js');
+  async createBatchIssues(
+    issues: CreateIssueInput[]
+  ): Promise<IssueBatchResponse> {
+    const { CREATE_BATCH_ISSUES } = await import("./mutations.js");
     return this.execute<IssueBatchResponse>(CREATE_BATCH_ISSUES, {
-      input: { issues }
+      input: { issues },
     });
   }
 
   // Helper method to create a project with associated issues
-  async createProjectWithIssues(projectInput: ProjectInput, issues: CreateIssueInput[]): Promise<ProjectResponse> {
+  async createProjectWithIssues(
+    projectInput: ProjectInput,
+    issues: CreateIssueInput[]
+  ): Promise<ProjectResponse> {
     // Create project first
     const projectResult = await this.createProject(projectInput);
-    
+
     if (!projectResult.projectCreate.success) {
-      throw new Error('Failed to create project');
+      throw new Error("Failed to create project");
     }
 
     // Then create issues with project ID
-    const issuesWithProject = issues.map(issue => ({
+    const issuesWithProject = issues.map((issue) => ({
       ...issue,
-      projectId: projectResult.projectCreate.project.id
+      projectId: projectResult.projectCreate.project.id,
     }));
 
     const issuesResult = await this.createBatchIssues(issuesWithProject);
 
     if (!issuesResult.issueBatchCreate.success) {
-      throw new Error('Failed to create issues');
+      throw new Error("Failed to create issues");
     }
 
     return {
       projectCreate: projectResult.projectCreate,
-      issueBatchCreate: issuesResult.issueBatchCreate
+      issueBatchCreate: issuesResult.issueBatchCreate,
     };
   }
 
   // Update a single issue
-  async updateIssue(id: string, input: UpdateIssueInput): Promise<UpdateIssuesResponse> {
-    const { UPDATE_ISSUES_MUTATION } = await import('./mutations.js');
+  async updateIssue(
+    id: string,
+    input: UpdateIssueInput
+  ): Promise<UpdateIssuesResponse> {
+    const { UPDATE_ISSUES_MUTATION } = await import("./mutations.js");
     return this.execute<UpdateIssuesResponse>(UPDATE_ISSUES_MUTATION, {
-      ids: [id],
+      id,
       input,
     });
   }
 
-  // Bulk update issues
-  async updateIssues(ids: string[], input: UpdateIssueInput): Promise<UpdateIssuesResponse> {
-    const { UPDATE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<UpdateIssuesResponse>(UPDATE_ISSUES_MUTATION, { ids, input });
+  // Bulk update issues - now calls updateIssue for each ID
+  async updateIssues(
+    ids: string[],
+    input: UpdateIssueInput
+  ): Promise<UpdateIssuesResponse> {
+    // Get the first ID to update
+    const firstId = ids[0];
+    if (!firstId) {
+      throw new Error("No issue IDs provided for update");
+    }
+
+    // Update the first issue
+    const result = await this.updateIssue(firstId, input);
+
+    // If there are more IDs, update them sequentially
+    if (ids.length > 1) {
+      for (let i = 1; i < ids.length; i++) {
+        await this.updateIssue(ids[i], input);
+      }
+    }
+
+    // Return the result from the first update
+    return result;
   }
 
   // Create multiple labels
   async createIssueLabels(labels: LabelInput[]): Promise<LabelResponse> {
-    const { CREATE_ISSUE_LABELS } = await import('./mutations.js');
+    const { CREATE_ISSUE_LABELS } = await import("./mutations.js");
     return this.execute<LabelResponse>(CREATE_ISSUE_LABELS, { labels });
   }
 
   // Search issues with pagination
   async searchIssues(
-    filter: SearchIssuesInput['filter'], 
-    first: number = 50, 
-    after?: string, 
+    filter: SearchIssuesInput["filter"],
+    first: number = 50,
+    after?: string,
     orderBy: string = "updatedAt"
   ): Promise<SearchIssuesResponse> {
-    const { SEARCH_ISSUES_QUERY } = await import('./queries.js');
+    const { SEARCH_ISSUES_QUERY } = await import("./queries.js");
     return this.execute<SearchIssuesResponse>(SEARCH_ISSUES_QUERY, {
       filter,
       first,
@@ -144,37 +175,43 @@ export class LinearGraphQLClient {
 
   // Get teams with their states and labels
   async getTeams(): Promise<TeamResponse> {
-    const { GET_TEAMS_QUERY } = await import('./queries.js');
+    const { GET_TEAMS_QUERY } = await import("./queries.js");
     return this.execute<TeamResponse>(GET_TEAMS_QUERY);
   }
 
   // Get current user info
   async getCurrentUser(): Promise<UserResponse> {
-    const { GET_USER_QUERY } = await import('./queries.js');
+    const { GET_USER_QUERY } = await import("./queries.js");
     return this.execute<UserResponse>(GET_USER_QUERY);
   }
 
   // Get project info
   async getProject(id: string): Promise<ProjectResponse> {
-    const { GET_PROJECT_QUERY } = await import('./queries.js');
+    const { GET_PROJECT_QUERY } = await import("./queries.js");
     return this.execute<ProjectResponse>(GET_PROJECT_QUERY, { id });
   }
 
   // Search projects
-  async searchProjects(filter: { name?: { eq: string } }): Promise<SearchProjectsResponse> {
-    const { SEARCH_PROJECTS_QUERY } = await import('./queries.js');
-    return this.execute<SearchProjectsResponse>(SEARCH_PROJECTS_QUERY, { filter });
+  async searchProjects(filter: {
+    name?: { eq: string };
+  }): Promise<SearchProjectsResponse> {
+    const { SEARCH_PROJECTS_QUERY } = await import("./queries.js");
+    return this.execute<SearchProjectsResponse>(SEARCH_PROJECTS_QUERY, {
+      filter,
+    });
   }
 
   // Delete a single issue
   async deleteIssue(id: string): Promise<DeleteIssueResponse> {
-    const { DELETE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<DeleteIssueResponse>(DELETE_ISSUES_MUTATION, { ids: [id] });
+    const { DELETE_ISSUES_MUTATION } = await import("./mutations.js");
+    return this.execute<DeleteIssueResponse>(DELETE_ISSUES_MUTATION, {
+      ids: [id],
+    });
   }
 
   // Delete multiple issues
   async deleteIssues(ids: string[]): Promise<DeleteIssueResponse> {
-    const { DELETE_ISSUES_MUTATION } = await import('./mutations.js');
+    const { DELETE_ISSUES_MUTATION } = await import("./mutations.js");
     return this.execute<DeleteIssueResponse>(DELETE_ISSUES_MUTATION, { ids });
   }
 }

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -1,4 +1,4 @@
-import { gql } from 'graphql-tag';
+import { gql } from "graphql-tag";
 
 export const CREATE_ISSUES_MUTATION = gql`
   mutation CreateIssues($input: [IssueCreateInput!]!) {
@@ -52,10 +52,10 @@ export const CREATE_BATCH_ISSUES = gql`
 `;
 
 export const UPDATE_ISSUES_MUTATION = gql`
-  mutation UpdateIssues($ids: [String!]!, $input: IssueUpdateInput!) {
-    issueUpdate(ids: $ids, input: $input) {
+  mutation UpdateIssues($id: String!, $input: IssueUpdateInput!) {
+    issueUpdate(id: $id, input: $input) {
       success
-      issues {
+      issue {
         id
         identifier
         title

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,4 +1,4 @@
-import { gql } from 'graphql-tag';
+import { gql } from "graphql-tag";
 
 export const SEARCH_ISSUES_QUERY = gql`
   query SearchIssues(
@@ -7,12 +7,7 @@ export const SEARCH_ISSUES_QUERY = gql`
     $after: String
     $orderBy: PaginationOrderBy
   ) {
-    issues(
-      filter: $filter
-      first: $first
-      after: $after
-      orderBy: $orderBy
-    ) {
+    issues(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
       pageInfo {
         hasNextPage
         endCursor
@@ -38,11 +33,11 @@ export const SEARCH_ISSUES_QUERY = gql`
           id
           name
           key
-        },
+        }
         project {
           id
           name
-        },
+        }
         priority
         labels {
           nodes {


### PR DESCRIPTION
# Release Notes - v1.0.1

## Fixes

*   **Authentication:** Corrected the handling of Linear Personal Access Tokens (PATs). The server now correctly uses the `apiKey` option when initializing the `@linear/sdk` client, resolving authentication errors caused by an incorrect "Bearer" prefix being added to PATs. (`src/auth.ts`)

## Documentation

*   **README Update:** Updated `README.md` to clarify the different methods for providing the `LINEAR_ACCESS_TOKEN`. It now emphasizes that for reliable integration with the VS Code Cline extension, the token **must** be provided in the `env` block of the `cline_mcp_settings.json` file. Instructions for finding the PAT in Linear settings were also improved.

## Known Issues

*   The server code does not currently load environment variables from a `.env` file automatically. This would require adding a dependency like `dotenv`.
*   Relying solely on system environment variables (e.g., from `.bashrc`) is not sufficient for the VS Code extension integration, as the extension requires the token to be explicitly defined in its `cline_mcp_settings.json` file.
