### PR TITLE
integration tests running

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:integration": "jest --testMatch '**/*.integration.test.ts'",
+    "test:integration": "jest --testPathPattern '\\.integration\\.test\\.ts$'",
     "get-test-tokens": "node --loader ts-node/esm scripts/get-test-tokens.ts",
     "test:oauth": "node --loader ts-node/esm scripts/test-oauth.ts",
     "build": "tsc && chmod +x build/index.js",


### PR DESCRIPTION
Fix for https://github.com/cline/linear-mcp/issues/8

both tests and integration tests now run

```
andrin@Andrins-MacBook-Pro linear-mcp % npm run test:integration

> linear-mcp@1.0.0 test:integration
> jest --testPathPattern '\.integration\.test\.ts$'

 PASS  src/__tests__/auth.integration.test.ts
  LinearAuth Integration
    Personal Access Token Authentication
      ✓ should authenticate with API Key
      ✓ should make authenticated requests with API Key
    OAuth Flow
      ○ skipped should generate valid authorization URL
      ○ skipped should exchange auth code for tokens
      ○ skipped should make authenticated requests with OAuth token

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 2 passed, 5 total
Snapshots:   0 total
Time:        0.972 s, estimated 1 s
Ran all test suites matching /\.integration\.test\.ts$/i.
andrin@Andrins-MacBook-Pro linear-mcp % npm run test            

> linear-mcp@1.0.0 test
> jest

 PASS  src/__tests__/auth.integration.test.ts
 PASS  src/__tests__/graphql-client.test.ts
 PASS  src/__tests__/auth.test.ts

Test Suites: 3 passed, 3 total
Tests:       3 skipped, 38 passed, 41 total
Snapshots:   0 total
Time:        1.009 s
Ran all test suites.
```