### PR TITLE
override deps for glob and lru-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "@modelcontextprotocol/sdk": "^1.4.0",
     "graphql": "^16.10.0",
     "graphql-tag": "^2.12.6"
+  },
+  "overrides": {
+    "glob": "^10.3.16",
+    "inflight": "npm:lru-cache@^10.2.0"
   }
 }


### PR DESCRIPTION
# Description
Added overrides for glob and inflight[->lru-cache] in response to https://github.com/cline/linear-mcp/issues/9

# Test Procedure
```
andrin@Andrins-MacBook-Pro linear-mcp % npm install

added 21 packages, removed 3 packages, changed 1 package, and audited 471 packages in 6s

74 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
andrin@Andrins-MacBook-Pro linear-mcp % npm install

up to date, audited 471 packages in 3s

74 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
andrin@Andrins-MacBook-Pro linear-mcp % npm list glob lru-cache
linear-mcp@1.0.0 /Users/andrin/Code/linear-mcp
├─┬ jest@29.7.0
│ └─┬ @jest/core@29.7.0
│   ├─┬ @jest/reporters@29.7.0
│   │ └─┬ glob@10.4.5 overridden
│   │   └─┬ path-scurry@1.11.1
│   │     └── lru-cache@10.4.3
│   ├─┬ jest-config@29.7.0
│   │ └── glob@10.4.5 deduped
│   └─┬ jest-runtime@29.7.0
│     └── glob@10.4.5 deduped
└─┬ ts-jest@29.3.2
  ├─┬ @babel/core@7.26.10
  │ └─┬ @babel/helper-compilation-targets@7.27.0
  │   └── lru-cache@5.1.1
  └─┬ @jest/transform@29.7.0
    └─┬ babel-plugin-istanbul@6.1.1
      └─┬ test-exclude@6.0.0
        └── glob@10.4.5 deduped

andrin@Andrins-MacBook-Pro linear-mcp % npm list inflight
linear-mcp@1.0.0 /Users/andrin/Code/linear-mcp
└── (empty)
andrin@Andrins-MacBook-Pro linear-mcp % npm run build          

> linear-mcp@1.0.0 build
> tsc && chmod +x build/index.js

andrin@Andrins-MacBook-Pro linear-mcp % npm test         

> linear-mcp@1.0.0 test
> jest

 PASS  src/__tests__/auth.integration.test.ts
 PASS  src/__tests__/graphql-client.test.ts
 PASS  src/__tests__/auth.test.ts

Test Suites: 3 passed, 3 total
Tests:       3 skipped, 38 passed, 41 total
Snapshots:   0 total
Time:        0.65 s, estimated 1 s
Ran all test suites.
```