### PR TITLE
Fix incorrect argument in single issue deletion 

### DIFF
--- a/src/__tests__/graphql-client.test.ts
+++ b/src/__tests__/graphql-client.test.ts
@@ -724,4 +724,31 @@ describe('LinearGraphQLClient', () => {
       );
     });
   });
+
+  describe("deleteIssue", () => {
+    it("should delete a single issue", async () => {
+      const mockResponse = {
+        data: {
+          issueDelete: {
+            success: true,
+          },
+        },
+      }
+
+      mockRawRequest.mockResolvedValueOnce(mockResponse)
+
+      const id = "issue-1"
+      const result: DeleteIssueResponse = await graphqlClient.deleteIssue(id)
+
+      expect(result).toEqual(mockResponse.data)
+      // Verify single mutation call
+      expect(mockRawRequest).toHaveBeenCalledTimes(1)
+      expect(mockRawRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          id,
+        })
+      )
+    })
+  })
 });

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -171,8 +171,10 @@ export class LinearGraphQLClient {
 
   // Delete a single issue
   async deleteIssue(id: string): Promise<DeleteIssueResponse> {
-    const { DELETE_ISSUES_MUTATION } = await import('./mutations.js');
-    return this.execute<DeleteIssueResponse>(DELETE_ISSUES_MUTATION, { ids: [id] });
+    const { DELETE_ISSUE_MUTATION } = await import('./mutations.js');
+    return this.execute<DeleteIssueResponse>(DELETE_ISSUE_MUTATION, {
+      id,
+    })
   }
 
   // Delete multiple issues

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -107,6 +107,14 @@ export const UPDATE_ISSUES_MUTATION = gql`
   }
 `;
 
+export const DELETE_ISSUE_MUTATION = gql`
+  mutation DeleteIssue($id: String!) {
+    issueDelete(id: $id) {
+      success
+    }
+  }
+`
+
 export const DELETE_ISSUES_MUTATION = gql`
   mutation DeleteIssues($ids: [String!]!) {
     issueDelete(ids: $ids) {


### PR DESCRIPTION
## Summary

This pull request fixes the linear_delete_issue function to correctly delete a single issue in Linear.

## Problem

Currently, when executing linear_delete_issue, the following error is raised:
```
Failed to delete issue: GraphQL operation failed: Unknown argument "ids" on field "Mutation.issueDelete". Did you mean "id"?
```
This indicates that the GraphQL mutation incorrectly uses ids (plural) instead of the expected id (singular).

## Changes
- Added a new mutation DELETE_ISSUE_MUTATION that correctly accepts a single id.
- Updated LinearGraphQLClient.deleteIssue to use DELETE_ISSUE_MUTATION instead of DELETE_ISSUES_MUTATION.
- Added a unit test to verify that a single issue can be deleted properly.
