### PR TITLE
feat: Added comment support for Linear

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The server currently supports the following operations:
 - ✅ Search issues with filtering
 - ✅ Associate issues with projects
 - ✅ Create parent/child issue relationships
+- ✅ Comment functionality (create/update/delete/view comments)
 
 ### Project Management
 - ✅ Create projects with associated issues
@@ -115,7 +116,6 @@ The server currently supports the following operations:
 The following features are currently being worked on:
 
 ### Issue Management
-- 🚧 Comment functionality (add/edit comments, threading)
 - 🚧 Complex search filters
 - 🚧 Pagination support for large result sets
 

--- a/src/__tests__/comment.test.ts
+++ b/src/__tests__/comment.test.ts
@@ -1,0 +1,214 @@
+import { CommentHandler } from '../features/comments/handlers/comment.handler';
+import { LinearAuth } from '../auth';
+import { LinearGraphQLClient } from '../graphql/client';
+import { CreateCommentResponse, UpdateCommentResponse, DeleteCommentResponse, GetCommentsResponse } from '../features/comments/types/comment.types';
+
+// Mock LinearAuth and LinearGraphQLClient
+jest.mock('../auth');
+jest.mock('../graphql/client');
+
+describe('CommentHandler', () => {
+  let commentHandler: CommentHandler;
+  let mockAuth: jest.Mocked<LinearAuth>;
+  let mockClient: jest.Mocked<LinearGraphQLClient>;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Create mock instances
+    mockAuth = new LinearAuth() as jest.Mocked<LinearAuth>;
+    mockClient = new LinearGraphQLClient(null as any) as jest.Mocked<LinearGraphQLClient>;
+
+    // Setup auth mock to return the client
+    mockAuth.getClient.mockReturnValue({} as any);
+    mockAuth.isAuthenticated.mockReturnValue(true);
+
+    // Create handler with mocks
+    commentHandler = new CommentHandler(mockAuth, mockClient);
+  });
+
+  describe('handleCreateComment', () => {
+    it('should create a comment successfully', async () => {
+      // Mock successful comment creation
+      const mockResponse: CreateCommentResponse = {
+        commentCreate: {
+          success: true,
+          comment: {
+            id: 'comment-123',
+            body: 'Test comment',
+            user: {
+              id: 'user-123',
+              name: 'Test User'
+            },
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            issue: {
+              id: 'issue-123',
+              identifier: 'TEST-123',
+              title: 'Test Issue'
+            }
+          }
+        }
+      };
+
+      mockClient.createComment.mockResolvedValue(mockResponse);
+
+      // Call the handler
+      const result = await commentHandler.handleCreateComment({
+        body: 'Test comment',
+        issueId: 'issue-123'
+      });
+
+      // Verify the result
+      expect(result).toBeDefined();
+      expect(result.content[0].type).toBe('text/plain');
+      expect(result.content[0].text).toContain('Successfully created comment');
+      expect(result.content[0].text).toContain('TEST-123');
+      
+      // Verify the client was called correctly
+      expect(mockClient.createComment).toHaveBeenCalledWith({
+        body: 'Test comment',
+        issueId: 'issue-123'
+      });
+    });
+
+    it('should handle failure when creating a comment', async () => {
+      // Mock failed comment creation
+      const mockResponse: CreateCommentResponse = {
+        commentCreate: {
+          success: false
+        }
+      };
+
+      mockClient.createComment.mockResolvedValue(mockResponse);
+
+      // Call the handler and expect it to throw
+      await expect(
+        commentHandler.handleCreateComment({
+          body: 'Test comment',
+          issueId: 'issue-123'
+        })
+      ).rejects.toThrow('Failed to create comment');
+    });
+  });
+
+  describe('handleUpdateComment', () => {
+    it('should update a comment successfully', async () => {
+      // Mock successful comment update
+      const mockResponse: UpdateCommentResponse = {
+        commentUpdate: {
+          success: true,
+          comment: {
+            id: 'comment-123',
+            body: 'Updated comment',
+            user: {
+              id: 'user-123',
+              name: 'Test User'
+            },
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          }
+        }
+      };
+
+      mockClient.updateComment.mockResolvedValue(mockResponse);
+
+      // Call the handler
+      const result = await commentHandler.handleUpdateComment({
+        id: 'comment-123',
+        body: 'Updated comment'
+      });
+
+      // Verify the result
+      expect(result).toBeDefined();
+      expect(result.content[0].type).toBe('text/plain');
+      expect(result.content[0].text).toContain('Successfully updated comment');
+      
+      // Verify the client was called correctly
+      expect(mockClient.updateComment).toHaveBeenCalledWith('comment-123', { body: 'Updated comment' });
+    });
+  });
+
+  describe('handleDeleteComment', () => {
+    it('should delete a comment successfully', async () => {
+      // Mock successful comment deletion
+      const mockResponse: DeleteCommentResponse = {
+        commentDelete: {
+          success: true
+        }
+      };
+
+      mockClient.deleteComment.mockResolvedValue(mockResponse);
+
+      // Call the handler
+      const result = await commentHandler.handleDeleteComment({
+        id: 'comment-123'
+      });
+
+      // Verify the result
+      expect(result).toBeDefined();
+      expect(result.content[0].type).toBe('text/plain');
+      expect(result.content[0].text).toContain('Successfully deleted comment');
+      
+      // Verify the client was called correctly
+      expect(mockClient.deleteComment).toHaveBeenCalledWith('comment-123');
+    });
+  });
+
+  describe('handleGetComments', () => {
+    it('should get comments successfully', async () => {
+      // Mock successful comments retrieval
+      const mockResponse: GetCommentsResponse = {
+        issue: {
+          comments: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null
+            },
+            nodes: [
+              {
+                id: 'comment-123',
+                body: 'Test comment',
+                user: {
+                  id: 'user-123',
+                  name: 'Test User'
+                },
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString()
+              }
+            ]
+          }
+        }
+      };
+
+      mockClient.getIssueComments.mockResolvedValue(mockResponse);
+
+      // Call the handler
+      const result = await commentHandler.handleGetComments({
+        issueId: 'issue-123',
+        first: 10
+      });
+
+      // Verify the result
+      expect(result).toBeDefined();
+      expect(result.content[0].type).toBe('application/json');
+      
+      // Verify the client was called correctly
+      expect(mockClient.getIssueComments).toHaveBeenCalledWith('issue-123', 10, undefined);
+    });
+
+    it('should handle failure when issue not found', async () => {
+      // Mock failed comments retrieval (issue not found)
+      const mockResponse = {};
+      mockClient.getIssueComments.mockResolvedValue(mockResponse as any);
+
+      // Call the handler and expect it to throw
+      await expect(
+        commentHandler.handleGetComments({
+          issueId: 'invalid-issue'
+        })
+      ).rejects.toThrow('Failed to get comments or issue not found');
+    });
+  });
+});

--- a/src/core/handlers/base.handler.ts
+++ b/src/core/handlers/base.handler.ts
@@ -39,7 +39,7 @@ export abstract class BaseHandler {
     return {
       content: [
         {
-          type: 'text',
+          type: 'text/plain',
           text,
         },
       ],
@@ -50,7 +50,14 @@ export abstract class BaseHandler {
    * Creates a JSON response with the given data.
    */
   protected createJsonResponse(data: unknown): BaseToolResponse {
-    return this.createResponse(JSON.stringify(data, null, 2));
+    return {
+      content: [
+        {
+          type: 'application/json',
+          text: JSON.stringify(data, null, 2),
+        },
+      ],
+    };
   }
 
   /**

--- a/src/core/handlers/handler.factory.ts
+++ b/src/core/handlers/handler.factory.ts
@@ -55,6 +55,8 @@ export class HandlerFactory {
       linear_update_comment: { handler: this.commentHandler, method: 'handleUpdateComment' },
       linear_delete_comment: { handler: this.commentHandler, method: 'handleDeleteComment' },
       linear_get_comments: { handler: this.commentHandler, method: 'handleGetComments' },
+      // Alias for backward compatibility
+      linear_get_issue_comments: { handler: this.commentHandler, method: 'handleGetComments' },
 
       // Project tools
       linear_create_project_with_issues: { handler: this.projectHandler, method: 'handleCreateProjectWithIssues' },

--- a/src/core/handlers/handler.factory.ts
+++ b/src/core/handlers/handler.factory.ts
@@ -2,6 +2,7 @@ import { LinearAuth } from '../../auth.js';
 import { LinearGraphQLClient } from '../../graphql/client.js';
 import { AuthHandler } from '../../features/auth/handlers/auth.handler.js';
 import { IssueHandler } from '../../features/issues/handlers/issue.handler.js';
+import { CommentHandler } from '../../features/comments/handlers/comment.handler.js';
 import { ProjectHandler } from '../../features/projects/handlers/project.handler.js';
 import { TeamHandler } from '../../features/teams/handlers/team.handler.js';
 import { UserHandler } from '../../features/users/handlers/user.handler.js';
@@ -13,6 +14,7 @@ import { UserHandler } from '../../features/users/handlers/user.handler.js';
 export class HandlerFactory {
   private authHandler: AuthHandler;
   private issueHandler: IssueHandler;
+  private commentHandler: CommentHandler;
   private projectHandler: ProjectHandler;
   private teamHandler: TeamHandler;
   private userHandler: UserHandler;
@@ -21,6 +23,7 @@ export class HandlerFactory {
     // Initialize all handlers with shared dependencies
     this.authHandler = new AuthHandler(auth, graphqlClient);
     this.issueHandler = new IssueHandler(auth, graphqlClient);
+    this.commentHandler = new CommentHandler(auth, graphqlClient);
     this.projectHandler = new ProjectHandler(auth, graphqlClient);
     this.teamHandler = new TeamHandler(auth, graphqlClient);
     this.userHandler = new UserHandler(auth, graphqlClient);
@@ -30,7 +33,7 @@ export class HandlerFactory {
    * Gets the appropriate handler for a given tool name.
    */
   getHandlerForTool(toolName: string): {
-    handler: AuthHandler | IssueHandler | ProjectHandler | TeamHandler | UserHandler;
+    handler: AuthHandler | IssueHandler | CommentHandler | ProjectHandler | TeamHandler | UserHandler;
     method: string;
   } {
     // Map tool names to their handlers and methods
@@ -46,6 +49,12 @@ export class HandlerFactory {
       linear_search_issues: { handler: this.issueHandler, method: 'handleSearchIssues' },
       linear_delete_issue: { handler: this.issueHandler, method: 'handleDeleteIssue' },
       linear_delete_issues: { handler: this.issueHandler, method: 'handleDeleteIssues' },
+
+      // Comment tools
+      linear_create_comment: { handler: this.commentHandler, method: 'handleCreateComment' },
+      linear_update_comment: { handler: this.commentHandler, method: 'handleUpdateComment' },
+      linear_delete_comment: { handler: this.commentHandler, method: 'handleDeleteComment' },
+      linear_get_comments: { handler: this.commentHandler, method: 'handleGetComments' },
 
       // Project tools
       linear_create_project_with_issues: { handler: this.projectHandler, method: 'handleCreateProjectWithIssues' },

--- a/src/core/interfaces/tool-handler.interface.ts
+++ b/src/core/interfaces/tool-handler.interface.ts
@@ -15,6 +15,12 @@ export interface ToolHandler {
   handleDeleteIssue(args: any): Promise<BaseToolResponse>;
   handleDeleteIssues(args: any): Promise<BaseToolResponse>;
 
+  // Comment Operations
+  handleCreateComment(args: any): Promise<BaseToolResponse>;
+  handleUpdateComment(args: any): Promise<BaseToolResponse>;
+  handleDeleteComment(args: any): Promise<BaseToolResponse>;
+  handleGetComments(args: any): Promise<BaseToolResponse>;
+
   // Project Operations
   handleCreateProjectWithIssues(args: any): Promise<BaseToolResponse>;
   handleGetProject(args: any): Promise<BaseToolResponse>;

--- a/src/core/types/tool.types.ts
+++ b/src/core/types/tool.types.ts
@@ -452,6 +452,32 @@ export const toolSchemas = {
     },
   },
 
+  // Alias for backward compatibility
+  linear_get_issue_comments: {
+    name: 'linear_get_issue_comments',
+    description: 'Get comments for an issue with pagination (alias for linear_get_comments)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issueId: {
+          type: 'string',
+          description: 'ID of the issue to get comments for',
+        },
+        first: {
+          type: 'number',
+          description: 'Number of comments to return (default: 50)',
+          optional: true,
+        },
+        after: {
+          type: 'string',
+          description: 'Cursor for pagination',
+          optional: true,
+        },
+      },
+      required: ['issueId'],
+    },
+  },
+
   linear_create_issues: {
     name: 'linear_create_issues',
     description: 'Create multiple issues at once',

--- a/src/core/types/tool.types.ts
+++ b/src/core/types/tool.types.ts
@@ -374,6 +374,84 @@ export const toolSchemas = {
     },
   },
 
+  linear_create_comment: {
+    name: 'linear_create_comment',
+    description: 'Create a new comment on an issue',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        body: {
+          type: 'string',
+          description: 'The comment text content',
+        },
+        issueId: {
+          type: 'string',
+          description: 'ID of the issue to comment on',
+        },
+      },
+      required: ['body', 'issueId'],
+    },
+  },
+
+  linear_update_comment: {
+    name: 'linear_update_comment',
+    description: 'Update an existing comment',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'ID of the comment to update',
+        },
+        body: {
+          type: 'string',
+          description: 'New comment text content',
+        },
+      },
+      required: ['id', 'body'],
+    },
+  },
+
+  linear_delete_comment: {
+    name: 'linear_delete_comment',
+    description: 'Delete a comment',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'ID of the comment to delete',
+        },
+      },
+      required: ['id'],
+    },
+  },
+
+  linear_get_comments: {
+    name: 'linear_get_comments',
+    description: 'Get comments for an issue with pagination',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issueId: {
+          type: 'string',
+          description: 'ID of the issue to get comments for',
+        },
+        first: {
+          type: 'number',
+          description: 'Number of comments to return (default: 50)',
+          optional: true,
+        },
+        after: {
+          type: 'string',
+          description: 'Cursor for pagination',
+          optional: true,
+        },
+      },
+      required: ['issueId'],
+    },
+  },
+
   linear_create_issues: {
     name: 'linear_create_issues',
     description: 'Create multiple issues at once',

--- a/src/features/comments/handlers/comment.handler.ts
+++ b/src/features/comments/handlers/comment.handler.ts
@@ -48,7 +48,7 @@ export class CommentHandler extends BaseHandler implements CommentHandlerMethods
         `Body: ${comment.body.substring(0, 50)}${comment.body.length > 50 ? '...' : ''}`
       );
     } catch (error) {
-      this.handleError(error, 'create comment');
+      return this.handleError(error, 'create comment');
     }
   }
 
@@ -76,7 +76,7 @@ export class CommentHandler extends BaseHandler implements CommentHandlerMethods
         `Body: ${comment.body.substring(0, 50)}${comment.body.length > 50 ? '...' : ''}`
       );
     } catch (error) {
-      this.handleError(error, 'update comment');
+      return this.handleError(error, 'update comment');
     }
   }
 
@@ -96,7 +96,7 @@ export class CommentHandler extends BaseHandler implements CommentHandlerMethods
 
       return this.createResponse(`Successfully deleted comment ${args.id}`);
     } catch (error) {
-      this.handleError(error, 'delete comment');
+      return this.handleError(error, 'delete comment');
     }
   }
 
@@ -121,7 +121,7 @@ export class CommentHandler extends BaseHandler implements CommentHandlerMethods
 
       return this.createJsonResponse(result);
     } catch (error) {
-      this.handleError(error, 'get comments');
+      return this.handleError(error, 'get comments');
     }
   }
 }

--- a/src/features/comments/handlers/comment.handler.ts
+++ b/src/features/comments/handlers/comment.handler.ts
@@ -1,0 +1,127 @@
+import { BaseHandler } from '../../../core/handlers/base.handler.js';
+import { BaseToolResponse } from '../../../core/interfaces/tool-handler.interface.js';
+import { LinearAuth } from '../../../auth.js';
+import { LinearGraphQLClient } from '../../../graphql/client.js';
+import {
+  CommentHandlerMethods,
+  CreateCommentInput,
+  UpdateCommentInput,
+  DeleteCommentInput,
+  GetCommentsInput,
+  CreateCommentResponse,
+  UpdateCommentResponse,
+  DeleteCommentResponse,
+  GetCommentsResponse
+} from '../types/comment.types.js';
+
+/**
+ * Handler for comment-related operations.
+ * Manages creating, updating, deleting, and retrieving comments.
+ */
+export class CommentHandler extends BaseHandler implements CommentHandlerMethods {
+  constructor(auth: LinearAuth, graphqlClient?: LinearGraphQLClient) {
+    super(auth, graphqlClient);
+  }
+
+  /**
+   * Creates a comment on an issue.
+   */
+  async handleCreateComment(args: CreateCommentInput): Promise<BaseToolResponse> {
+    try {
+      const client = this.verifyAuth();
+      this.validateRequiredParams(args, ['body', 'issueId']);
+
+      const result = await client.createComment(args) as CreateCommentResponse;
+
+      if (!result.commentCreate.success || !result.commentCreate.comment) {
+        throw new Error('Failed to create comment');
+      }
+
+      const comment = result.commentCreate.comment;
+      const issueIdentifier = comment.issue?.identifier || 'Unknown';
+
+      return this.createResponse(
+        `Successfully created comment on issue ${issueIdentifier}\n` +
+        `Comment ID: ${comment.id}\n` +
+        `Created: ${new Date(comment.createdAt).toLocaleString()}\n` +
+        `By: ${comment.user.name}\n` +
+        `Body: ${comment.body.substring(0, 50)}${comment.body.length > 50 ? '...' : ''}`
+      );
+    } catch (error) {
+      this.handleError(error, 'create comment');
+    }
+  }
+
+  /**
+   * Updates an existing comment.
+   */
+  async handleUpdateComment(args: UpdateCommentInput): Promise<BaseToolResponse> {
+    try {
+      const client = this.verifyAuth();
+      this.validateRequiredParams(args, ['id', 'body']);
+
+      const result = await client.updateComment(args.id, { body: args.body }) as UpdateCommentResponse;
+
+      if (!result.commentUpdate.success || !result.commentUpdate.comment) {
+        throw new Error('Failed to update comment');
+      }
+
+      const comment = result.commentUpdate.comment;
+
+      return this.createResponse(
+        `Successfully updated comment\n` +
+        `Comment ID: ${comment.id}\n` +
+        `Updated: ${new Date(comment.updatedAt).toLocaleString()}\n` +
+        `By: ${comment.user.name}\n` +
+        `Body: ${comment.body.substring(0, 50)}${comment.body.length > 50 ? '...' : ''}`
+      );
+    } catch (error) {
+      this.handleError(error, 'update comment');
+    }
+  }
+
+  /**
+   * Deletes a comment.
+   */
+  async handleDeleteComment(args: DeleteCommentInput): Promise<BaseToolResponse> {
+    try {
+      const client = this.verifyAuth();
+      this.validateRequiredParams(args, ['id']);
+
+      const result = await client.deleteComment(args.id) as DeleteCommentResponse;
+
+      if (!result.commentDelete.success) {
+        throw new Error('Failed to delete comment');
+      }
+
+      return this.createResponse(`Successfully deleted comment ${args.id}`);
+    } catch (error) {
+      this.handleError(error, 'delete comment');
+    }
+  }
+
+  /**
+   * Gets comments for an issue with pagination support.
+   */
+  async handleGetComments(args: GetCommentsInput): Promise<BaseToolResponse> {
+    try {
+      const client = this.verifyAuth();
+      this.validateRequiredParams(args, ['issueId']);
+
+      const first = args.first || 50;
+      const result = await client.getIssueComments(
+        args.issueId,
+        first,
+        args.after
+      ) as GetCommentsResponse;
+
+      if (!result.issue || !result.issue.comments) {
+        throw new Error('Failed to get comments or issue not found');
+      }
+
+      return this.createJsonResponse(result);
+    } catch (error) {
+      this.handleError(error, 'get comments');
+    }
+  }
+}

--- a/src/features/comments/types/comment.types.ts
+++ b/src/features/comments/types/comment.types.ts
@@ -1,0 +1,93 @@
+import { BaseToolResponse } from '../../../core/interfaces/tool-handler.interface.js';
+
+/**
+ * Input types for comment operations
+ */
+
+export interface CreateCommentInput {
+  body: string;
+  issueId: string;
+}
+
+export interface CommentUpdateInput {
+  body: string;
+}
+
+export interface UpdateCommentInput {
+  id: string;
+  body: string;
+}
+
+export interface DeleteCommentInput {
+  id: string;
+}
+
+export interface GetCommentsInput {
+  issueId: string;
+  first?: number;
+  after?: string;
+}
+
+/**
+ * Response types for comment operations
+ */
+
+export interface Comment {
+  id: string;
+  body: string;
+  user: {
+    id: string;
+    name: string;
+    email?: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  issue?: {
+    id: string;
+    identifier: string;
+    title: string;
+  };
+}
+
+export interface CreateCommentResponse {
+  commentCreate: {
+    success: boolean;
+    comment?: Comment;
+  };
+}
+
+export interface UpdateCommentResponse {
+  commentUpdate: {
+    success: boolean;
+    comment?: Comment;
+  };
+}
+
+export interface DeleteCommentResponse {
+  commentDelete: {
+    success: boolean;
+  };
+}
+
+export interface GetCommentsResponse {
+  issue: {
+    comments: {
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string | null;
+      };
+      nodes: Comment[];
+    };
+  };
+}
+
+/**
+ * Handler method types
+ */
+
+export interface CommentHandlerMethods {
+  handleCreateComment(args: CreateCommentInput): Promise<BaseToolResponse>;
+  handleUpdateComment(args: UpdateCommentInput): Promise<BaseToolResponse>;
+  handleDeleteComment(args: DeleteCommentInput): Promise<BaseToolResponse>;
+  handleGetComments(args: GetCommentsInput): Promise<BaseToolResponse>;
+}

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -14,6 +14,15 @@ import {
   IssueBatchResponse
 } from '../features/issues/types/issue.types.js';
 import {
+  CreateCommentInput,
+  UpdateCommentInput,
+  CommentUpdateInput,
+  CreateCommentResponse,
+  UpdateCommentResponse,
+  DeleteCommentResponse,
+  GetCommentsResponse
+} from '../features/comments/types/comment.types.js';
+import {
   ProjectInput,
   ProjectResponse,
   SearchProjectsResponse
@@ -181,5 +190,39 @@ export class LinearGraphQLClient {
   async deleteIssues(ids: string[]): Promise<DeleteIssueResponse> {
     const { DELETE_ISSUES_MUTATION } = await import('./mutations.js');
     return this.execute<DeleteIssueResponse>(DELETE_ISSUES_MUTATION, { ids });
+  }
+
+  // Comment operations
+  
+  // Create a comment
+  async createComment(input: CreateCommentInput): Promise<CreateCommentResponse> {
+    const { CREATE_COMMENT_MUTATION } = await import('./comment-mutations.js');
+    return this.execute<CreateCommentResponse>(CREATE_COMMENT_MUTATION, { input });
+  }
+
+  // Update a comment
+  async updateComment(id: string, input: CommentUpdateInput): Promise<UpdateCommentResponse> {
+    const { UPDATE_COMMENT_MUTATION } = await import('./comment-mutations.js');
+    return this.execute<UpdateCommentResponse>(UPDATE_COMMENT_MUTATION, { id, input });
+  }
+
+  // Delete a comment
+  async deleteComment(id: string): Promise<DeleteCommentResponse> {
+    const { DELETE_COMMENT_MUTATION } = await import('./comment-mutations.js');
+    return this.execute<DeleteCommentResponse>(DELETE_COMMENT_MUTATION, { id });
+  }
+
+  // Get comments for an issue
+  async getIssueComments(
+    issueId: string,
+    first: number = 50,
+    after?: string
+  ): Promise<GetCommentsResponse> {
+    const { GET_ISSUE_COMMENTS_QUERY } = await import('./comment-queries.js');
+    return this.execute<GetCommentsResponse>(GET_ISSUE_COMMENTS_QUERY, {
+      issueId,
+      first,
+      after
+    });
   }
 }

--- a/src/graphql/comment-mutations.ts
+++ b/src/graphql/comment-mutations.ts
@@ -1,0 +1,52 @@
+import { gql } from 'graphql-tag';
+
+export const CREATE_COMMENT_MUTATION = gql`
+  mutation CreateComment($input: CommentCreateInput!) {
+    commentCreate(input: $input) {
+      success
+      comment {
+        id
+        body
+        user {
+          id
+          name
+          email
+        }
+        createdAt
+        updatedAt
+        issue {
+          id
+          identifier
+          title
+        }
+      }
+    }
+  }
+`;
+
+export const UPDATE_COMMENT_MUTATION = gql`
+  mutation UpdateComment($id: String!, $input: CommentUpdateInput!) {
+    commentUpdate(id: $id, input: $input) {
+      success
+      comment {
+        id
+        body
+        user {
+          id
+          name
+          email
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const DELETE_COMMENT_MUTATION = gql`
+  mutation DeleteComment($id: String!) {
+    commentDelete(id: $id) {
+      success
+    }
+  }
+`;

--- a/src/graphql/comment-queries.ts
+++ b/src/graphql/comment-queries.ts
@@ -1,0 +1,25 @@
+import { gql } from 'graphql-tag';
+
+export const GET_ISSUE_COMMENTS_QUERY = gql`
+  query GetIssueComments($issueId: String!, $first: Int, $after: String) {
+    issue(id: $issueId) {
+      comments(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          body
+          user {
+            id
+            name
+            email
+          }
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`;

--- a/todo.md
+++ b/todo.md
@@ -88,6 +88,7 @@
 - [ ] Create API documentation
 - [ ] Add examples for common operations
 - [ ] Document error handling strategies
+- [x] Implement comment functionality
 
 ### Testing
 - [x] Add unit tests for new type definitions


### PR DESCRIPTION
# ✨ Add Comment Support for Linear MCP

## Summary
This PR introduces full comment functionality to the Linear MCP, enabling users to create, update, delete, and retrieve comments associated with issues. It also includes a backward compatibility layer for retrieving issue comments via a legacy alias, and improves the consistency of error handling across comment-related operations.

## 🆕 Features
Create Comment: Ability to add comments to Linear issues.

Update Comment: Edit existing comments.

Delete Comment: Remove comments by ID.

Retrieve Comments: Fetch all comments associated with a given issue.

## 🔄 Backward Compatibility
Introduced an alias to maintain compatibility with systems expecting the previous method for fetching issue comments.

## 🛠 Fixes & Improvements
Refactored error handling logic across comment endpoints to ensure errors are returned in a consistent and predictable format.

## 📌 Notes
These enhancements lay the groundwork for richer collaborative features in the MCP. Please review with an eye on edge cases around comment ownership and permissions (if relevant to your context).