### PR TITLE
feat: add linear_link_issues and linear_unlink_issues tools for issue relationships

### DIFF
--- a/src/core/handlers/handler.factory.ts
+++ b/src/core/handlers/handler.factory.ts
@@ -52,6 +52,8 @@ export class HandlerFactory {
       linear_search_issues: { handler: this.issueHandler, method: 'handleSearchIssues' },
       linear_delete_issue: { handler: this.issueHandler, method: 'handleDeleteIssue' },
       linear_delete_issues: { handler: this.issueHandler, method: 'handleDeleteIssues' },
+      linear_link_issues: { handler: this.issueHandler, method: 'handleLinkIssues' },
+      linear_unlink_issues: { handler: this.issueHandler, method: 'handleUnlinkIssues' },
 
       // Project tools
       linear_create_project_with_issues: { handler: this.projectHandler, method: 'handleCreateProjectWithIssues' },

--- a/src/core/types/tool.types.ts
+++ b/src/core/types/tool.types.ts
@@ -344,6 +344,44 @@ export const toolSchemas = {
     },
   },
 
+  linear_link_issues: {
+    name: 'linear_link_issues',
+    description: 'Create a relationship between two issues (blocks, depends on, related, duplicate, etc.)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issueId: {
+          type: 'string',
+          description: 'The source issue ID (UUID)',
+        },
+        relatedIssueId: {
+          type: 'string',
+          description: 'The target issue ID (UUID) to link to',
+        },
+        type: {
+          type: 'string',
+          description: 'Relationship type: "blocks" (this blocks other), "blockedBy" (blocked by other), "relates" (related to), "duplicate" (is duplicate), "duplicateOf" (original of duplicate)',
+        },
+      },
+      required: ['issueId', 'relatedIssueId', 'type'],
+    },
+  },
+
+  linear_unlink_issues: {
+    name: 'linear_unlink_issues',
+    description: 'Remove a relationship between two issues',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        relationId: {
+          type: 'string',
+          description: 'The relationship ID to delete',
+        },
+      },
+      required: ['relationId'],
+    },
+  },
+
   linear_get_project: {
     name: 'linear_get_project',
     description: 'Get project information',

--- a/src/features/issues/handlers/issue.handler.ts
+++ b/src/features/issues/handlers/issue.handler.ts
@@ -253,4 +253,60 @@ export class IssueHandler extends BaseHandler implements IssueHandlerMethods {
       this.handleError(error, 'delete issues');
     }
   }
+
+  /**
+   * Creates a relationship between two issues (parent/child, blocks, depends on, etc.)
+   */
+  async handleLinkIssues(args: { issueId: string; relatedIssueId: string; type: string }): Promise<BaseToolResponse> {
+    try {
+      const client = this.verifyAuth();
+      this.validateRequiredParams(args, ['issueId', 'relatedIssueId', 'type']);
+
+      // Validate relationship type
+      const validTypes = ['blocks', 'blockedBy', 'relates', 'duplicate', 'duplicateOf'];
+      if (!validTypes.includes(args.type)) {
+        throw new Error(`Invalid relationship type. Must be one of: ${validTypes.join(', ')}`);
+      }
+
+      const result = await client.createIssueRelation({
+        issueId: args.issueId,
+        relatedIssueId: args.relatedIssueId,
+        type: args.type
+      }) as any;
+
+      if (!result.issueRelationCreate.success) {
+        throw new Error('Failed to create issue relationship');
+      }
+
+      const relation = result.issueRelationCreate.issueRelation;
+
+      return this.createResponse(
+        `Successfully created relationship\n` +
+        `Relationship: ${relation.issue.identifier} ${args.type} ${relation.relatedIssue.identifier}\n` +
+        `Type: ${relation.type}`
+      );
+    } catch (error) {
+      this.handleError(error, 'link issues');
+    }
+  }
+
+  /**
+   * Removes a relationship between two issues.
+   */
+  async handleUnlinkIssues(args: { relationId: string }): Promise<BaseToolResponse> {
+    try {
+      const client = this.verifyAuth();
+      this.validateRequiredParams(args, ['relationId']);
+
+      const result = await client.deleteIssueRelation(args.relationId) as any;
+
+      if (!result.issueRelationDelete.success) {
+        throw new Error('Failed to delete issue relationship');
+      }
+
+      return this.createResponse(`Successfully removed issue relationship`);
+    } catch (error) {
+      this.handleError(error, 'unlink issues');
+    }
+  }
 }

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -259,4 +259,16 @@ export class LinearGraphQLClient {
       orderBy: options.orderBy || 'updatedAt'
     });
   }
+
+  // Create an issue relationship
+  async createIssueRelation(input: { issueId: string; relatedIssueId: string; type: string }): Promise<any> {
+    const { CREATE_ISSUE_RELATION_MUTATION } = await import('./mutations.js');
+    return this.execute<any>(CREATE_ISSUE_RELATION_MUTATION, { input });
+  }
+
+  // Delete an issue relationship
+  async deleteIssueRelation(id: string): Promise<any> {
+    const { DELETE_ISSUE_RELATION_MUTATION } = await import('./mutations.js');
+    return this.execute<any>(DELETE_ISSUE_RELATION_MUTATION, { id });
+  }
 }

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -231,3 +231,35 @@ export const DELETE_PROJECT_MILESTONE_MUTATION = gql`
     }
   }
 `;
+
+export const CREATE_ISSUE_RELATION_MUTATION = gql`
+  mutation CreateIssueRelation($input: IssueRelationCreateInput!) {
+    issueRelationCreate(input: $input) {
+      success
+      issueRelation {
+        id
+        type
+        issue {
+          id
+          identifier
+          title
+        }
+        relatedIssue {
+          id
+          identifier
+          title
+        }
+      }
+      lastSyncId
+    }
+  }
+`;
+
+export const DELETE_ISSUE_RELATION_MUTATION = gql`
+  mutation DeleteIssueRelation($id: String!) {
+    issueRelationDelete(id: $id) {
+      success
+      lastSyncId
+    }
+  }
+`;


### PR DESCRIPTION
## Summary

- Add GraphQL mutations for creating and deleting issue relationships
- Add createIssueRelation and deleteIssueRelation methods to GraphQLClient
- Add handleLinkIssues method to create relationships (blocks, blockedBy, relates, duplicate, duplicateOf)
- Add handleUnlinkIssues method to remove relationships
- Support relationship validation and clear error messages
- Register both tools in HandlerFactory
- All unit tests pass (56/56)

## Supported Relationship Types
- blocks: This issue blocks another
- blockedBy: This issue is blocked by another
- relates: This issue is related to another
- duplicate: This issue is a duplicate
- duplicateOf: This issue is the original of a duplicate

## Changes
- src/graphql/mutations.ts: Added CREATE_ISSUE_RELATION_MUTATION and DELETE_ISSUE_RELATION_MUTATION
- src/graphql/client.ts: Added createIssueRelation and deleteIssueRelation methods
- src/features/issues/handlers/issue.handler.ts: Added handleLinkIssues and handleUnlinkIssues methods
- src/core/types/tool.types.ts: Added linear_link_issues and linear_unlink_issues tool schemas
- src/core/handlers/handler.factory.ts: Registered both tools in handler map

## Testing
- ✅ TypeScript compilation successful
- ✅ All 56 unit tests passing
- ✅ Code follows existing patterns and conventions